### PR TITLE
Feat(payment): Support async Stripe methods

### DIFF
--- a/layers/base/app/components/checkout/PaymentForm.vue
+++ b/layers/base/app/components/checkout/PaymentForm.vue
@@ -24,25 +24,38 @@ const paymentMethods = computed(
 
 const checkoutState = useState<CheckoutState>("checkoutState");
 const state = checkoutState.value.paymentForm;
-const addressForm = useTemplateRef("stripeElement");
+const stripeElement = useTemplateRef("stripeElementRef");
 
 async function onSubmit() {
   if (!state.code) return;
+
   orderStore.error = null;
+  orderStore.loading = true;
 
   // Note: consider a switch or a composable if more methods are added later
   if (state.code === "standard-payment") {
     await orderStore.transitionToState("ArrangingPayment");
-    if (orderStore.error) return;
+    if (orderStore.error) {
+      orderStore.loading = false;
+      return;
+    }
+
     await orderStore.addPaymentToOrder({ method: state.code, metadata: {} });
-    if (orderStore.error) return;
+    if (orderStore.error) {
+      orderStore.loading = false;
+      return;
+    }
   } else if (state.code === "stripe-payment") {
-    orderStore.loading = true;
-    await addressForm.value?.submitStripePayment();
-    orderStore.loading = false;
-    if (orderStore.error) return;
+    await orderStore.transitionToState("ArrangingPayment");
+    if (orderStore.error) {
+      orderStore.loading = false;
+      return;
+    }
+
+    await stripeElement.value?.submitStripePayment();
   }
 
+  orderStore.loading = false;
   isSubmitted.value = true;
 }
 
@@ -87,7 +100,7 @@ async function onError() {
 
     <CheckoutStripeElement
       v-if="state.code === 'stripe-payment'"
-      ref="stripeElement"
+      ref="stripeElementRef"
     />
   </UForm>
 </template>

--- a/layers/base/app/components/checkout/StripeElement.vue
+++ b/layers/base/app/components/checkout/StripeElement.vue
@@ -1,7 +1,7 @@
 <script setup lang="ts">
 import type { CheckoutState } from "~~/types/general";
 
-const { stripePublicKey } = useRuntimeConfig().public;
+const { stripeAccountId, stripePublicKey } = useRuntimeConfig().public;
 const colorMode = useColorMode();
 const { locale } = useI18n();
 const { onLoaded } = useScriptStripe();
@@ -37,7 +37,10 @@ watch(colorMode, () => {
 
 onMounted(() => {
   onLoaded(async ({ Stripe }) => {
-    stripe.value = Stripe(stripePublicKey, { locale: locale.value });
+    stripe.value = Stripe(stripePublicKey, {
+      stripeAccount: stripeAccountId,
+      locale: locale.value,
+    });
 
     if (state.code === "stripe-payment") {
       const { createStripePaymentIntent } =

--- a/layers/base/app/pages/checkout/confirmation/[code].client.vue
+++ b/layers/base/app/pages/checkout/confirmation/[code].client.vue
@@ -4,15 +4,36 @@ import { h } from "vue";
 import type { TableColumn } from "@nuxt/ui";
 import type { OrderLineRow } from "~~/types/general";
 
-const { locale, t } = useI18n();
-const localePath = useLocalePath();
-const route = useRoute();
-const code = route.params.code as string;
-const isMounted = ref(false);
-
 definePageMeta({
   alias: ["/order/:code"],
 });
+
+const { locale, t } = useI18n();
+const localePath = useLocalePath();
+const route = useRoute();
+const router = useRouter();
+const toast = useToast();
+const orderStore = useOrderStore();
+
+const code = route.params.code as string;
+const isMounted = ref(false);
+
+const redirectStatus = computed(
+  () => route.query.redirect_status as string | undefined,
+);
+const paymentIntent = computed(
+  () => route.query.payment_intent as string | undefined,
+);
+
+const isStripeReturn = computed(() => {
+  return !!paymentIntent.value;
+});
+
+const isSuccessfulStripeReturn = computed(() => {
+  return redirectStatus.value === "succeeded";
+});
+
+const isPending = ref(false);
 
 const {
   data: orderData,
@@ -23,30 +44,30 @@ const {
 const order = computed(() => orderData.value?.orderByCode ?? null);
 const hasError = computed(() => !!error.value);
 
+const transitionalStates = ["AddingItems", "ArrangingPayment"];
+
+async function sleep(ms: number) {
+  await new Promise((resolve) => setTimeout(resolve, ms));
+}
+
 async function pollOrder(maxAttempts = 20, interval = 2000) {
   let attempts = 0;
+
   while (attempts < maxAttempts) {
     attempts++;
     await refresh();
 
-    if (error.value) {
-      console.error("Error during order polling:", error.value);
-      break;
-    }
-
     const state = order.value?.state;
-    const initialStates = ["AddingItems", "ArrangingPayment"];
 
-    if (!state) {
-      console.warn("Order state missing during polling, attempt", attempts);
-      await new Promise((res) => setTimeout(res, interval));
+    if (!state || transitionalStates.includes(state)) {
+      await sleep(interval);
       continue;
     }
 
-    if (!initialStates.includes(state)) break;
-
-    await new Promise((res) => setTimeout(res, interval));
+    return true;
   }
+
+  return false;
 }
 
 const formatPrice = (amount: number) =>
@@ -103,14 +124,73 @@ function printReceipt() {
   }
 }
 
-onMounted(() => {
+onMounted(async () => {
   isMounted.value = true;
-  pollOrder();
+
+  if (
+    isStripeReturn.value &&
+    redirectStatus.value &&
+    !isSuccessfulStripeReturn.value
+  ) {
+    await orderStore.transitionToState("AddingItems");
+    await router.replace(localePath("/checkout"));
+
+    toast.add({
+      title: t("messages.error.general"),
+      description: t("messages.error.generalMessage"),
+      color: "error",
+    });
+
+    return;
+  } else if (
+    isStripeReturn.value &&
+    redirectStatus.value &&
+    isSuccessfulStripeReturn.value
+  ) {
+    await orderStore.addPaymentToOrder({
+      method: "stripe-payment",
+      metadata: {
+        isAsyncRedirect: true,
+        paymentIntentId: paymentIntent.value,
+      } as Record<string, unknown>,
+    });
+
+    // TODO: investigate why the active order state is not rehydrated/reset here
+    // like it is in the normal COD/non-redirect checkout success flow.
+    orderStore.order = null;
+
+    await router.replace(
+      localePath(`/checkout/confirmation/${route.params.code}`),
+    );
+  }
+
+  const state = order.value?.state;
+
+  if (!state || transitionalStates.includes(state)) {
+    isPending.value = true;
+    const resolved = await pollOrder();
+    isPending.value = false;
+
+    if (!resolved) {
+      console.error("Order confirmation polling timed out", {
+        code,
+        state: order.value?.state,
+        redirectStatus: redirectStatus.value,
+        paymentIntent: paymentIntent.value,
+        hasError: hasError.value,
+        error: error.value,
+      });
+      return;
+    }
+  }
 });
 </script>
 
 <template>
-  <BaseLoader v-if="!isMounted && !order" width="sm:w-xs md:w-sm" />
+  <BaseLoader
+    v-if="(!isMounted && !order) || isPending"
+    width="sm:w-xs md:w-sm"
+  />
 
   <UError
     v-else-if="isMounted && hasError"

--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -32,6 +32,7 @@ export default defineNuxtConfig({
       GQL_HOST: process.env.GQL_HOST,
       channelToken: process.env.CHANNEL_TOKEN,
       i18NBaseUrl: process.env.I18N_BASE_URL,
+      stripeAccountId: process.env.STRIPE_ACCOUNT_ID,
       stripePublicKey: process.env.STRIPE_PUBLIC_KEY,
       unsplashApiKey: process.env.UNSPLASH_API_KEY,
     },


### PR DESCRIPTION
## Summary
This PR improves the Stripe checkout flow by adding support for asynchronous payment methods, wiring `stripeAccount` into Stripe Elements for Connect scenarios, and moving order confirmation behavior to the client side.

## Changes
- add support for async Stripe payment methods, including bank transfer
- pass `stripeAccount` when creating Stripe Elements
- move order confirmation flow to client-only to resolve the related GraphQL error

## Result
The checkout flow now better supports Stripe Connect and async payment flows, and the confirmation page avoids the previous SSR/GQL issue.